### PR TITLE
Do not override file.opts.filenameRelative

### DIFF
--- a/src/moduleImportHelper.js
+++ b/src/moduleImportHelper.js
@@ -26,7 +26,8 @@ function getImportedModuleFile(crntFile, importedModulePath) {
     ...crntFile,
     opts: {
       ...crntFile.opts,
-      filename: (crntFile.opts.filenameRelative = importedModulePath + '.js'),
+      filename: importedModulePath + '.js',
+      filenameRelative: importedModulePath + '.js',
     },
     getModuleName: crntFile.getModuleName,
   };

--- a/test/fixtures/amd/getModuleId/.babelrc_extra
+++ b/test/fixtures/amd/getModuleId/.babelrc_extra
@@ -1,0 +1,21 @@
+{
+  "moduleIds": true,
+  "getModuleId": {
+    "npmModule": "npmModuleGlobalVar",
+    "PATH/actual": "actualGlobalVar"
+  },
+  "plugins": [
+    ["system-import-transformer", {
+      "modules": "amd"
+    }]
+  ],
+  "presets": [
+    [
+        "@babel/preset-env",
+      {
+            "modules": "amd",
+            "useBuiltIns": false
+      }
+    ]
+  ]
+}

--- a/test/fixtures/amd/getModuleId/actual.js
+++ b/test/fixtures/amd/getModuleId/actual.js
@@ -1,0 +1,3 @@
+System.import('npmModule');
+
+// System.import('./myModule');

--- a/test/fixtures/amd/getModuleId/expected.js
+++ b/test/fixtures/amd/getModuleId/expected.js
@@ -1,0 +1,21 @@
+define('actualGlobalVar', [], function() {
+  'use strict';
+  var _systemImportTransformerGlobalIdentifier =
+    typeof window !== 'undefined'
+      ? window
+      : typeof self !== 'undefined'
+      ? self
+      : typeof global !== 'undefined'
+      ? global
+      : {};
+
+  new Promise(function(resolve, reject) {
+    _systemImportTransformerGlobalIdentifier.require(
+      ['npmModuleGlobalVar'],
+      resolve,
+      reject,
+    );
+  });
+});
+
+// System.import('./myModule');

--- a/test/index.js
+++ b/test/index.js
@@ -57,14 +57,22 @@ function runTests() {
   return result;
 }
 
-function createBabelModuleIdProvider(fileMap) {
+function createBabelModuleIdProvider(fileMap, crntPath) {
   return function babelModuleIdProvider(moduleName) {
     // const fileMap = {
     //   'myModule': 'myModuleGlobalconst'
     // };
 
-    const result = fileMap[moduleName] || moduleName.replace('src/', '');
-    return result;
+    if (fileMap[moduleName]) {
+      return fileMap[moduleName];
+    }
+
+    const pathMap = moduleName.replace(crntPath, 'PATH');
+    if (fileMap[pathMap]) {
+      return fileMap[pathMap];
+    }
+
+    return moduleName.replace('src/', '');
   };
 }
 
@@ -83,6 +91,7 @@ function getBabelConfiguration(dir) {
       if (extraConfiguration.getModuleId) {
         extraConfiguration.getModuleId = createBabelModuleIdProvider(
           extraConfiguration.getModuleId,
+          crntPath,
         );
       }
       configurations.push(extraConfiguration);


### PR DESCRIPTION
As raised in #19, the filenameRelative of the crntFile.opts was being overridden rather than copied over.